### PR TITLE
fix definition of Q_xy

### DIFF
--- a/w06a-DiscreteStochasticProcesses.ipynb
+++ b/w06a-DiscreteStochasticProcesses.ipynb
@@ -100,7 +100,7 @@
     "$$\n",
     "This problem is readily recast as a differential equation, often called [Master equation](https://en.wikipedia.org/wiki/Master_equation)\n",
     "$$\n",
-    "\\frac{d p_j}{dt} = Q_{ji}p_i\n",
+    "\\frac{d p_j}{dt} = \\sum_i Q_{ji}p_i\n",
     "$$\n",
     "where $Q_{ji}$ is the rate of change from $i$ to $j$, while the diagonal elements obey the condition\n",
     "$$\n",
@@ -109,7 +109,7 @@
     "which essentially means \"everything that is leaving state $i$ is ends up somewhere else\".\n",
     "In other words, the [transition rate matrix](https://en.wikipedia.org/wiki/Transition-rate_matrix) preserves probability by definition\n",
     "$$\n",
-    "\\sum_j \\frac{d p_j}{dt} = \\sum_j Q_{ji}p_i = \\left(\\sum_{j\\neq i}Q_{ji} - \\sum_{j\\neq i}Q_{ji} \\right)p_i = 0\n",
+    "\\sum_j \\frac{d p_j}{dt} = \\sum_{j,i} Q_{ji}p_i = \\sum_i \\left(\\sum_{j\\neq i}Q_{ji} - \\sum_{j\\neq i}Q_{ji} \\right)p_i = 0\n",
     "$$\n",
     "(so called stochastic matrices have a columns sum that equals one instead of 0). "
    ]

--- a/w06a-DiscreteStochasticProcesses.ipynb
+++ b/w06a-DiscreteStochasticProcesses.ipynb
@@ -76,7 +76,7 @@
     "\\end{split}\n",
     "$$\n",
     "The last line implies the intuition that over a short time in a discrete state space, the systems stays in the same state in most cases and the probability to switch is linear in $\\Delta t$.\n",
-    "Notice how the (off-diagonal) elements of the $Q_{xy}(t) = \\frac{d}{dt} P(\\{x,t+\\Delta\\}|\\{y,t\\})$ matrix represent transition rates from state $y$ to state $x$.\n",
+    "Notice how the (off-diagonal) elements of the $Q_{xy}(t) = \\frac{d}{d\\Delta t} P(\\{x,t\\}|\\{y,t-\\Delta t\\})|_{\\Delta t = 0}$ matrix represent transition rates from state $y$ to state $x$.\n",
     "Rearranging this leads to a linear equation for the probability distribution:\n",
     "$$\n",
     "\\frac{d}{dt} P\\left(\\{x,t\\}|\\{x_{0}, t_{0}\\} \\right) = \\sum_y Q_{xy}(t)P\\left(\\{y,t\\}|\\{x_{0}, t_{0}\\}\\right)\n",


### PR DESCRIPTION
I had a short discussion with Greta about the definition of $Q_{xy}$ and I think the correct definition is with derivative w.r.t. $\Delta t$, namely the following change:

$$
Q_{xy}(t) = \frac{d}{dt} P(\\{x,t+\Delta\\}|\\{y,t\\})  \quad \Rightarrow \quad \frac{d}{d\Delta} P(\\{x,t+\Delta\\}|\\{y,t\\})
$$

I also did some more cosmetic changes:
- $\Delta \to \Delta t$
- moved $+\Delta t$ from the $x$ side to $-\Delta t$ on the $y$ side to better match the derivation

So that now it looks like this:

$$
Q_{xy}(t) = \\frac{d}{d\\Delta t} P(\\{x,t\\}|\\{y,t-\\Delta t\\})|_{\\Delta t = 0}
$$

I think you modified this part at some point so wanted to double-check with you first.

(I also added some more sums after talking again with Greta, but up to you depending if you'd rather stick to Einstein notation)